### PR TITLE
Document how to reset Qdrant volume after storage corruption

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,23 @@ docker compose up -d backend
 
 > Примечание: backend ожидает, что Ollama доступна по `http://localhost:11434`. В docker-compose.yml добавлен `extra_hosts: host.docker.internal:host-gateway`, поэтому сервис внутри контейнера обращается к Ollama на машине-хосте по адресу `http://host.docker.internal:11434`.
 
+### Если Qdrant не стартует
+
+После обновлений образа или неудачного завершения работы том `legal_ai_1c_qdrant_data` может содержать неконсистентные данные. В таком случае `docker compose up` выводит ошибку вроде:
+
+```
+qdrant | ERROR qdrant::startup: Panic occurred ... Failed to (de)serialize from/to json: invalid type: sequence, expected a map
+```
+
+Очистите том и поднимите контейнер заново:
+
+```bash
+./scripts/reset_qdrant_volume.sh
+docker compose up -d qdrant
+```
+
+Скрипт остановит работающий контейнер Qdrant (если он запущен), удалит именованный том и напомнит перезапустить сервис. Перед очисткой сделайте бэкап, если в Qdrant были нужные данные.
+
 ---
 
 

--- a/scripts/reset_qdrant_volume.sh
+++ b/scripts/reset_qdrant_volume.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VOLUME_NAME=${1:-legal_ai_1c_qdrant_data}
+CONTAINER_NAME=${2:-qdrant}
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker CLI is required" >&2
+  exit 1
+fi
+
+if ! docker volume inspect "$VOLUME_NAME" >/dev/null 2>&1; then
+  echo "Volume '$VOLUME_NAME' does not exist. Nothing to reset."
+  exit 0
+fi
+
+if docker ps -a --format '{{.Names}}' | grep -qx "$CONTAINER_NAME"; then
+  echo "Stopping running qdrant container: $CONTAINER_NAME"
+  docker stop "$CONTAINER_NAME" >/dev/null 2>&1 || true
+fi
+
+echo "Removing volume '$VOLUME_NAME'"
+docker volume rm "$VOLUME_NAME"
+
+echo "Qdrant volume has been reset. Run 'docker compose up -d qdrant' to recreate it."


### PR DESCRIPTION
## Summary
- document how to recover when the Qdrant container crashes because of a corrupted storage volume
- add a helper script that stops the Qdrant container and removes the stale volume