### PR TITLE
Add ingestion of local PDF legal acts into sample corpus

### DIFF
--- a/backend/app_core/rag/pdf_loader.py
+++ b/backend/app_core/rag/pdf_loader.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import List
+
+try:  # pragma: no cover - optional dependency
+    from pypdf import PdfReader  # type: ignore
+except Exception:  # noqa: S110
+    PdfReader = None  # type: ignore
+
+from .html_extract import split_into_chunks
+from ..types import IngestItem
+
+
+class PdfLoaderUnavailable(RuntimeError):
+    """Выбрасывается, если модуль pypdf недоступен."""
+
+
+def _require_pdf_reader() -> None:
+    if PdfReader is None:  # pragma: no cover - зависит от окружения
+        raise PdfLoaderUnavailable("pypdf is not installed; cannot ingest PDF documents")
+
+
+def _sanitize_title(text: str) -> str:
+    cleaned = re.sub(r"\s+", " ", text).strip()
+    return cleaned[:300]
+
+
+def _derive_act_title(raw_text: str, fallback: str) -> str:
+    for line in raw_text.splitlines():
+        candidate = line.strip()
+        if len(candidate) < 6:
+            continue
+        # отбрасываем номера страниц и одиночные цифры
+        if re.fullmatch(r"\d+", candidate):
+            continue
+        return _sanitize_title(candidate)
+    return fallback
+
+
+def _slugify(name: str) -> str:
+    slug = name.strip().lower()
+    slug = re.sub(r"[\s\-/]+", "_", slug, flags=re.UNICODE)
+    slug = re.sub(r"[^\w]+", "_", slug, flags=re.UNICODE)
+    slug = re.sub(r"_+", "_", slug).strip("_")
+    return slug or "document"
+
+
+def pdf_to_ingest_items(path: Path, *, max_chars: int = 1800, overlap: int = 120) -> List[IngestItem]:
+    """Читает PDF-файл и возвращает чанки текста для загрузки в RAG."""
+
+    _require_pdf_reader()
+
+    reader = PdfReader(str(path))
+    pages: List[str] = []
+    for page in reader.pages:
+        try:
+            text = page.extract_text() or ""
+        except Exception as exc:  # noqa: BLE001 - продолжаем, но логируем
+            raise RuntimeError(f"cannot extract text from {path}: {exc}")
+        cleaned = text.replace("\r\n", "\n").replace("\r", "\n").strip()
+        if cleaned:
+            pages.append(cleaned)
+
+    if not pages:
+        return []
+
+    full_text = "\n\n".join(pages)
+    act_title = _derive_act_title(full_text, _sanitize_title(path.stem))
+    act_id = _slugify(path.stem)
+    base_ref = f"ru_law/{act_id}"
+
+    chunks = split_into_chunks(full_text, max_chars=max_chars, overlap=overlap)
+    items: List[IngestItem] = []
+    for idx, chunk in enumerate(chunks, start=1):
+        body = chunk.strip()
+        if not body:
+            continue
+        items.append(
+            IngestItem(
+                act_id=act_id,
+                act_title=act_title,
+                article=None,
+                part=None,
+                point=None,
+                revision_date=None,
+                jurisdiction="RU",
+                text=body,
+                local_ref=f"{base_ref}/chunk{idx}",
+            )
+        )
+
+    return items

--- a/backend/app_core/rag/store.py
+++ b/backend/app_core/rag/store.py
@@ -1,5 +1,8 @@
-import json, os, numpy as np
-from typing import List
+import json
+from pathlib import Path
+from typing import List, Dict, Any
+
+import numpy as np
 
 try:  # pragma: no cover - optional dependency
     from qdrant_client import QdrantClient  # type: ignore
@@ -9,6 +12,7 @@ except Exception:  # noqa: S110
     VectorParams = Distance = PointStruct = Filter = FieldCondition = MatchValue = None  # type: ignore
 
 from .embedder import get_embedder
+from .pdf_loader import pdf_to_ingest_items, PdfLoaderUnavailable
 from ..types import IngestItem, SourceItem
 from ..config import settings
 from ..utils import deterministic_point_id, text_hash
@@ -82,14 +86,49 @@ def rag_search_ru(query: str, top_k: int = 8) -> List[SourceItem]:
 
 def ingest_sample_from_file():
     ensure_collection()
-    path = "/workspace/corpus/ru_sample.jsonl"
-    if not os.path.exists(path):
+
+    path = Path("/workspace/corpus/ru_sample.jsonl")
+    if not path.exists():
         raise FileNotFoundError("Файл corpus/ru_sample.jsonl не найден")
+
     items: List[IngestItem] = []
-    with open(path, "r", encoding="utf-8") as f:
+    jsonl_records = 0
+    with path.open("r", encoding="utf-8") as f:
         for line in f:
             line = line.strip()
-            if not line: continue
+            if not line:
+                continue
             data = json.loads(line)
             items.append(IngestItem(**data))
-    return ingest_items(items)
+            jsonl_records += 1
+
+    pdf_dir = Path("/workspace/corpus/Законодательные акты")
+    pdf_files = 0
+    pdf_chunks = 0
+    pdf_errors: List[Dict[str, Any]] = []
+    if pdf_dir.exists():
+        pdf_paths = sorted(pdf_dir.rglob("*.pdf"))
+        for pdf_path in pdf_paths:
+            try:
+                pdf_items = pdf_to_ingest_items(pdf_path)
+            except PdfLoaderUnavailable as exc:
+                pdf_errors.append({"file": str(pdf_path), "error": str(exc)})
+                break
+            except Exception as exc:  # noqa: BLE001 - логируем и продолжаем
+                pdf_errors.append({"file": str(pdf_path), "error": str(exc)})
+                continue
+            if not pdf_items:
+                continue
+            items.extend(pdf_items)
+            pdf_files += 1
+            pdf_chunks += len(pdf_items)
+
+    res = ingest_items(items)
+    res.update({
+        "jsonl_records": jsonl_records,
+        "pdf_files": pdf_files,
+        "pdf_chunks": pdf_chunks,
+    })
+    if pdf_errors:
+        res["pdf_errors"] = pdf_errors
+    return res

--- a/backend/app_core/routes/ingest.py
+++ b/backend/app_core/routes/ingest.py
@@ -9,7 +9,7 @@ from urllib.parse import urlparse, urlunparse
 from ..types import IngestItem, IngestPayload  
 from ..config import settings
 
-from ..rag.store import ingest_items, ensure_collection
+from ..rag.store import ingest_items, ensure_collection, ingest_sample_from_file
 from ..rag.pub_pravo import parse_publication_html
 from ..rag.gk_txt import parse_gk_file
 
@@ -19,20 +19,12 @@ router = APIRouter(prefix="/rag")
 @router.post("/ingest_sample")
 def rag_ingest_sample():
     """
-    Загружает demo-корпус из corpus/ru_sample.jsonl
+    Загружает demo-корпус и локальные PDF-документы из /workspace/corpus.
     """
-    ensure_collection()
-    import json, pathlib, hashlib
-    p = pathlib.Path("/workspace/corpus/ru_sample.jsonl")
-    if not p.exists():
-        return {"error": f"not found: {p}"}
-    items: List[IngestItem] = []
-    for line in p.read_text(encoding="utf-8").splitlines():
-        if not line.strip():
-            continue
-        d = json.loads(line)
-        items.append(IngestItem(**d))
-    return ingest_items(items)
+    try:
+        return ingest_sample_from_file()
+    except FileNotFoundError as exc:
+        return {"error": str(exc)}
 
 
 @router.post("/ingest")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,3 +9,4 @@ PyYAML>=6.0.1,<7.0
 sentence-transformers>=3.0.1,<3.1
 FlagEmbedding>=1.2.10,<1.3
 qdrant-client>=1.9.1,<2.0
+pypdf>=4.2.0,<5.0


### PR DESCRIPTION
## Summary
- add a PDF loader that chunks legal acts from `corpus/Законодательные акты/*.pdf` into RAG ingest items
- extend the sample ingest flow to combine the demo JSONL corpus with the new PDF documents and report ingestion stats
- require the `pypdf` dependency for PDF extraction