### PR TITLE
Add Docker Compose stack for backend and dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,30 @@ docker run --rm \
 
 > На macOS/Windows параметр `--add-host` не требуется: `host.docker.internal` уже настроен Docker Desktop.
 
+## Запуск через Docker Compose
+
+В репозитории есть `docker-compose.yml`, который поднимает backend вместе с Ollama и Qdrant.
+
+```bash
+docker compose up -d
+```
+
+По умолчанию публикуются порты 8087 (backend), 11434 (Ollama) и 6333/6334 (Qdrant). Каталог `./corpus` подключается к backend в
+режиме чтения, а отчёты из сервиса сохраняются в локальную папку `./reports`.
+
+После первого запуска зайдите в контейнер Ollama и загрузите нужные модели:
+
+```bash
+docker compose exec ollama ollama pull krith/qwen2.5-32b-instruct:IQ4_XS
+docker compose exec ollama ollama pull BAAI/bge-m3
+```
+
+Остановка сервисов:
+
+```bash
+docker compose down
+```
+
 ## Основные переменные окружения
 
 | Переменная | Значение по умолчанию | Назначение |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+    container_name: legal-ai-backend
+    environment:
+      OLLAMA_BASE_URL: http://ollama:11434
+      QDRANT_URL: http://qdrant:6333
+    ports:
+      - "8087:8087"
+    volumes:
+      - ./corpus:/app/corpus:ro
+      - ./reports:/app/reports
+    depends_on:
+      - ollama
+      - qdrant
+    restart: unless-stopped
+
+  qdrant:
+    image: qdrant/qdrant:latest
+    container_name: legal-ai-qdrant
+    ports:
+      - "6333:6333"
+      - "6334:6334"
+    volumes:
+      - qdrant_data:/qdrant/storage
+    restart: unless-stopped
+
+  ollama:
+    image: ollama/ollama:latest
+    container_name: legal-ai-ollama
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    restart: unless-stopped
+
+volumes:
+  qdrant_data:
+  ollama_data:


### PR DESCRIPTION
## Summary
- add a Docker Compose configuration that starts the FastAPI backend together with Ollama and Qdrant
- document how to launch and manage the stack, including pulling the required Ollama models